### PR TITLE
Ignore classes which implement the TestCase interface

### DIFF
--- a/runway
+++ b/runway
@@ -101,6 +101,11 @@ foreach($paths as $path) {
 		// Get the code
 		require $commandPath;
 
+		// Ignore classes extending TestCase
+		if(is_subclass_of($command, PHPUnit\Framework\TestCase::class)) {
+			continue;
+		}
+
 		// Add the command
 		$consoleApp->add(new $command($config));
 	}


### PR DESCRIPTION
The new path collection algorithm from [f704f3c](https://github.com/flightphp/runway/commit/f704f3c7991d07fa64597a2b6a65bb2b1e435643) might be a bit over-agressive.
For example, it also collects the [tests\commands\RecordCommandTest](https://github.com/flightphp/active-record/blob/master/tests/commands/RecordCommandTest.php) class from flightphp\active-record.
This prevents runway from working when active-record is installed.

By ignoring classes which implement PHPUnit\Framework\TestCase, I was able to get runway up and running again on my machine.